### PR TITLE
Fetch post + comment data and store in hashmaps

### DIFF
--- a/src/hn_client.rs
+++ b/src/hn_client.rs
@@ -29,31 +29,25 @@ enum Route {
 }
 
 #[derive(Debug)]
-pub enum Children {
-    Loaded(Vec<Comment>),
-    NotLoaded(Vec<u32>),
-}
-
-#[derive(Debug)]
 pub struct Post {
-    id: u32,
-    by: String,
-    children: Children,
-    title: String,
-    time: u32,
-    url: Option<String>,
-    text: Option<String>,
-    descendants: u32,
+    pub id: u32,
+    pub by: String,
+    pub children: Vec<u32>,
+    pub title: String,
+    pub time: u32,
+    pub url: Option<String>,
+    pub text: Option<String>,
+    pub descendants: u32,
 }
 
 #[derive(Debug)]
 pub struct Comment {
-    id: u32,
-    by: String,
-    children: Children,
-    parent: u32,
-    text: String,
-    time: u32,
+    pub id: u32,
+    pub by: String,
+    pub children: Vec<u32>,
+    pub parent: u32,
+    pub text: String,
+    pub time: u32,
 }
 
 // Defined by https://github.com/HackerNews/API#items
@@ -172,7 +166,6 @@ pub enum StoryListType {
 }
 
 // Returns top 500 stories - also contains jobs
-// TODO - convert this to take in top / best / new
 pub async fn get_stories(
     story_type: StoryListType,
     skip: usize,
@@ -198,7 +191,7 @@ pub async fn get_stories(
             Item::Story(story) => Post {
                 id: story.id,
                 by: story.by,
-                children: Children::NotLoaded(story.kids),
+                children: story.kids,
                 title: story.title,
                 time: story.time,
                 url: story.url,
@@ -228,7 +221,7 @@ pub async fn get_comments(children: &Vec<u32>) -> Result<Vec<Comment>, Box<dyn s
             Item::Comment(comment) => Comment {
                 id: comment.id,
                 by: comment.by,
-                children: Children::NotLoaded(comment.kids),
+                children: comment.kids,
                 parent: comment.parent,
                 text: comment.text,
                 time: comment.time,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,30 @@
 mod hn_client;
+use hn_client::{Post, Comment};
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Fetch top 20 + get data
-    let results = hn_client::get_stories(hn_client::StoryListType::Top, 0, 20).await?;
-    println!("{:?}", results);
+    let mut top_posts: Vec<u32> = Vec::new();
+    let mut post_hash: HashMap<u32, Post> = HashMap::new();
+    let mut comment_hash: HashMap<u32, Comment> = HashMap::new();
+
+    let posts = hn_client::get_stories(hn_client::StoryListType::Top, 0, 20).await?;
+    for post in posts {
+        top_posts.push(post.id);
+        post_hash.insert(post.id, post);
+    }
+
+    if top_posts.len() > 0 {
+        let id = top_posts[1];
+        let post = post_hash.get(&id).unwrap();
+        let comments = hn_client::get_comments(&post.children).await?;
+
+        for comment in comments {
+            comment_hash.insert(comment.id, comment);
+        }
+    }
+
+    println!("{:?}", post_hash);
+    println!("{:?}", comment_hash);
     Ok(())
 }


### PR DESCRIPTION
Removed comments enum - was difficult to figure out how to switch enums mutably (attempted code here https://github.com/niclim/rust-hn-client/pull/4). Instead moving to storing data in hashmaps + get the renderer to generate the UI from two hashmaps (comments + posts)